### PR TITLE
closing HTML tag for inline math fixed

### DIFF
--- a/src/render_html.ml
+++ b/src/render_html.ml
@@ -54,7 +54,7 @@ object(self)
       | InlineMath(inlines) ->
          self#add_string "<span class=\"inline_math\">";
          self#render_inlines inlines;
-         self#add_string "<span class=\"inline_math\">";
+         self#add_string "</span>";
       | Bold(inlines) ->
          self#add_string "<b>";
          self#render_inlines inlines;


### PR DESCRIPTION
This fixes a typo in the HTML renderer, inline math is currently rendered as:

```
<span class="inline_math">foo<span class="inline_math">
```

instead of:

```
<span class="inline_math">foo</span>
```
